### PR TITLE
Fix bug multiple filters return no results multipleRange and others

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -60,7 +60,7 @@ class Filter
         return $this;
     }
 
-    public function toRedisParams(): string
+    public function toRedisParams(): array
     {
         $params = [];
         foreach ($this->filters as $filter) {
@@ -85,6 +85,6 @@ class Filter
                     break;
             }
         }
-        return implode(' ', $params);
+        return $params;
     }
 }

--- a/src/TimeSeries.php
+++ b/src/TimeSeries.php
@@ -293,7 +293,8 @@ class TimeSeries
         return $this->redis->executeCommand(array_merge(
             $params,
             $this->getAggregationParams($rule),
-            ['FILTER', $filter->toRedisParams()]
+            ['FILTER'],
+            $filter->toRedisParams()
         ));
     }
 

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -75,13 +75,7 @@ class IntegrationTest extends TestCase
         $filter = new Filter('sensor_id', '2');
         $filter->add('area_id', Filter::OP_EQUALS, '32');
 
-        $range = $this->sut->multiRange(
-            $filter,
-            null,
-            null,
-            null,
-            null
-        );
+        $range = $this->sut->multiRange($filter);
 
         $expectedRange = [
             new Sample('temperature:3:11', 30, new DateTimeImmutable('2019-11-06 20:34:17.103000')),

--- a/tests/Unit/FilterTest.php
+++ b/tests/Unit/FilterTest.php
@@ -68,7 +68,7 @@ class FilterTest extends TestCase
         $filter->add('lab6', Filter::OP_NOT_IN, ['d', 'e', 'f']);
 
         $result = $filter->toRedisParams();
-        $expected = 'lab1=val1 lab2!=val2 lab3= lab4!= lab5=(a,b,c) lab6!=(d,e,f)';
+        $expected = ['lab1=val1', 'lab2!=val2', 'lab3=', 'lab4!=', 'lab5=(a,b,c)', 'lab6!=(d,e,f)'];
 
         $this->assertEquals($expected, $result);
     }

--- a/tests/Unit/TimeSeriesTest.php
+++ b/tests/Unit/TimeSeriesTest.php
@@ -299,7 +299,7 @@ class TimeSeriesTest extends TestCase
         $this->redisClientMock
             ->expects($this->once())
             ->method('executeCommand')
-            ->with(['TS.MGET', 'FILTER', 'a=a1'])
+            ->with(['TS.MGET', 'FILTER', ['a=a1']])
             ->willReturn([
                 ['a', [['a', 'a1'], ['b', 'b1']], 1483300866234, '7'],
                 ['b', [['a', 'a1'], ['c', 'c1']], 1522923630234, '7.1'],
@@ -401,9 +401,10 @@ class TimeSeriesTest extends TestCase
         $this->redisClientMock
             ->expects($this->once())
             ->method('executeCommand')
-            ->with(['TS.QUERYINDEX', 'a=a1'])
+            ->with(['TS.QUERYINDEX', ['a=a1']])
             ->willReturn($keys);
         $response = $this->sut->getKeysByFilter(new Filter('a', 'a1'));
+
         $this->assertEquals($keys, $response);
     }
 }


### PR DESCRIPTION
When `Filter` is used to fetch data, redis returns no results if filter params is not `array`.