### PR TITLE
Fix date time rounding issue for range and multirange

### DIFF
--- a/src/TimeSeries.php
+++ b/src/TimeSeries.php
@@ -225,8 +225,8 @@ class TimeSeries
         ?AggregationRule $rule = null
     ): array
     {
-        $fromTs = $from ? (int)$from->format('Uu') / 1000 : '-';
-        $toTs = $to ? (int)$to->format('Uu') / 1000 : '+';
+        $fromTs = $from ? DateTimeUtils::timestampWithMsFromDateTime($from) : '-';
+        $toTs = $to ? DateTimeUtils::timestampWithMsFromDateTime($to) : '+';
 
         $params = ['TS.RANGE', $key, $fromTs, $toTs];
         if ($count !== null) {
@@ -292,8 +292,8 @@ class TimeSeries
         ?AggregationRule $rule = null
     ): array
     {
-        $fromTs = $from ? (int)$from->format('Uu') / 1000 : '-';
-        $toTs = $to ? (int)$to->format('Uu') / 1000 : '+';
+        $fromTs = $from ? DateTimeUtils::timestampWithMsFromDateTime($from) : '-';
+        $toTs = $to ? DateTimeUtils::timestampWithMsFromDateTime($to) : '+';
 
         $params = ['TS.MRANGE', $fromTs, $toTs];
         if ($count !== null) {

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 
 namespace Palicao\PhpRedisTimeSeries\Tests\Integration;
 
+use DateInterval;
+use DateTime;
 use DateTimeImmutable;
 use Palicao\PhpRedisTimeSeries\AggregationRule;
+use Palicao\PhpRedisTimeSeries\DateTimeUtils;
 use Palicao\PhpRedisTimeSeries\Filter;
 use Palicao\PhpRedisTimeSeries\Label;
 use Palicao\PhpRedisTimeSeries\RedisClient;
@@ -150,4 +153,64 @@ class IntegrationTest extends TestCase
         $this->assertEquals($expectedResult, $range);
     }
 
+    public function testAddAndRetrieveWithDateTimeObjectAsMultiRangeWithMultipleFilters(): void
+    {
+        $currentDate = new DateTime();
+        $from = $currentDate->sub(new DateInterval('P1D'));
+        $to = $currentDate;
+
+        $this->sut->create(
+            'temperature:3:11',
+            6000,
+            [new Label('sensor_id', '2'), new Label('area_id', '32')]
+        );
+        $this->sut->add(new Sample('temperature:3:11', 30, $from));
+        $this->sut->add(new Sample('temperature:3:11', 42, $to));
+
+        $filter = new Filter('sensor_id', '2');
+        $filter->add('area_id', Filter::OP_EQUALS, '32');
+
+        $range = $this->sut->multiRange($filter);
+
+        $expectedRange = [
+            Sample::createFromTimestamp('temperature:3:11', (float)42, DateTimeUtils::timestampWithMsFromDateTime(new DateTimeImmutable($to->format('Y-m-d H:i:s.u'))))
+        ];
+
+        $this->assertEquals($expectedRange, $range);
+    }
+
+
+    public function testAddAndRetrieveWithDateTimeObjectAsRange(): void
+    {
+        $from = new DateTimeImmutable('2019-11-06 20:34:17.103000');
+        $to = new DateTimeImmutable('2019-11-06 20:34:17.107000');
+
+        $this->sut->create(
+            'temperature:3:11',
+            null,
+            [new Label('sensor_id', '2'), new Label('area_id', '32')]
+        );
+
+        $this->sut->add(new Sample('temperature:3:11', 30, $from));
+        $this->sut->add(new Sample('temperature:3:11', 42, $to));
+
+        $range = $this->sut->range(
+            'temperature:3:11'
+        );
+
+        $expectedRange = [
+            Sample::createFromTimestamp(
+                'temperature:3:11',
+                (float)30,
+                DateTimeUtils::timestampWithMsFromDateTime(new DateTimeImmutable($from->format('Y-m-d H:i:s.u')))
+            ),
+            Sample::createFromTimestamp(
+                'temperature:3:11',
+                (float)42,
+                DateTimeUtils::timestampWithMsFromDateTime(new DateTimeImmutable($to->format('Y-m-d H:i:s.u')))
+            ),
+        ];
+
+        $this->assertEquals($expectedRange, $range);
+    }
 }


### PR DESCRIPTION
When add data to timeseries and using `new DateTime()` object, library rounds it to 1 decimal point and redis does not like that.

This is a fix with existing utils and some integration tests.