### PR TITLE
Move "package-versions" to dev deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     },
     "require": {
         "php": ">=7.2.0",
-        "ext-redis": "*",
-        "ocramius/package-versions": "1.4.2"
+        "ext-redis": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.3",
-        "vimeo/psalm": "^3.5"
+        "vimeo/psalm": "^3.5",
+        "ocramius/package-versions": "1.4.2"
     }
 }


### PR DESCRIPTION
`ocramius/package-versions` should be a dev dependency. currently installation fails with:

```Using version ^2.0 for palicao/php-redis-time-series
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: don't install palicao/php-redis-time-series 2.0.3
    - Conclusion: don't install palicao/php-redis-time-series 2.0.2
    - Conclusion: don't install palicao/php-redis-time-series 2.0.1
    - Conclusion: remove composer/package-versions-deprecated 1.8.1
    - Installation request for palicao/php-redis-time-series ^2.0 -> satisfiable by palicao/php-redis-time-series[2.0.0, 2.0.1, 2.0.2, 2.0.3].
    - Conclusion: don't install composer/package-versions-deprecated 1.8.1
    - palicao/php-redis-time-series 2.0.0 requires ocramius/package-versions 1.4.2 -> satisfiable by composer/package-versions-deprecated[1.8.0], ocramius/package-versions[1.4.2].
    - Can only install one of: composer/package-versions-deprecated[1.8.0, 1.8.1].
    - don't install ocramius/package-versions 1.4.2|don't install composer/package-versions-deprecated 1.8.1
    - Installation request for composer/package-versions-deprecated (locked at 1.8.1) -> satisfiable by composer/package-versions-deprecated[1.8.1].
```