### PR TITLE
allow inheriting from TimeSeries class

### DIFF
--- a/src/TimeSeries.php
+++ b/src/TimeSeries.php
@@ -9,7 +9,7 @@ use Palicao\PhpRedisTimeSeries\Exception\InvalidDuplicatePolicyException;
 use Palicao\PhpRedisTimeSeries\Exception\RedisClientException;
 use RedisException;
 
-final class TimeSeries
+class TimeSeries
 {
     public const DUPLICATE_POLICY_BLOCK = 'BLOCK';
     public const DUPLICATE_POLICY_FIRST = 'FIRST';
@@ -18,7 +18,7 @@ final class TimeSeries
     public const DUPLICATE_POLICY_MAX = 'MAX';
     public const DUPLICATE_POLICY_SUM = 'SUM';
 
-    private const DUPLICATE_POLICIES = [
+    protected const DUPLICATE_POLICIES = [
         self::DUPLICATE_POLICY_BLOCK,
         self::DUPLICATE_POLICY_FIRST,
         self::DUPLICATE_POLICY_LAST,
@@ -29,7 +29,7 @@ final class TimeSeries
 
 
     /** @var RedisClientInterface */
-    private $redis;
+    protected $redis;
 
     /**
      * @param RedisClientInterface $redis

--- a/tests/Integration/ExtendTest.php
+++ b/tests/Integration/ExtendTest.php
@@ -1,0 +1,40 @@
+<?php
+/* @noinspection PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace Palicao\PhpRedisTimeSeries\Tests\Integration;
+
+use Palicao\PhpRedisTimeSeries\Client\RedisClient;
+use Palicao\PhpRedisTimeSeries\Client\RedisConnectionParams;
+use Palicao\PhpRedisTimeSeries\TimeSeries;
+use PHPUnit\Framework\TestCase;
+use Redis;
+
+class MyTimeSeries extends TimeSeries
+{
+    public function getRedis()
+    {
+        return $this->redis;
+    }
+}
+
+class ExtendTest extends TestCase
+{
+    private $redisClient;
+    private $sut;
+
+    public function setUp(): void
+    {
+        $host = getenv('REDIS_HOST') ?: 'php-rts-redis';
+        $port = getenv('REDIS_PORT') ? (int) getenv('REDIS_PORT') : 6379;
+        $connectionParams = new RedisConnectionParams($host, $port);
+        $this->redisClient = new RedisClient(new Redis(), $connectionParams);
+        $this->sut = new MyTimeSeries($this->redisClient);
+    }
+
+    public function testRedisPropertyScope(): void
+    {
+        self::assertSame($this->redisClient, $this->sut->getRedis());
+    }
+}


### PR DESCRIPTION
i needed to subclass `TimeSeries` to add functionality but then was bitten by `private`ness of things as those properties are exclusive to the defining scope.

this opens up the class to make it easier to quickly modify behavior.