### PR TITLE
fix TS.INFO parsing

### DIFF
--- a/src/TimeSeries.php
+++ b/src/TimeSeries.php
@@ -516,7 +516,7 @@ final class TimeSeries
         );
     }
 
-    protected function parseInfo(array $info)
+    protected function parseInfo(array $info): array
     {
         $chunks = array_chunk($info, 2);
         $props = [];

--- a/src/TimeSeries.php
+++ b/src/TimeSeries.php
@@ -518,7 +518,7 @@ final class TimeSeries
 
     protected function parseInfo(array $info)
     {
-        $chunks = array_chunk($result, 2);
+        $chunks = array_chunk($info, 2);
         $props = [];
         foreach ($chunks as $chunk) {
             $props[$chunk[0]] = $chunk[1];

--- a/src/TimeSeries.php
+++ b/src/TimeSeries.php
@@ -509,7 +509,7 @@ final class TimeSeries
             $result['lastTimestamp'],
             $result['retentionTime'],
             $result['chunkCount'],
-            $result['maxSamplesPerChunk'],
+            $result['chunkSize'],
             $labels,
             $sourceKey,
             $rules
@@ -523,6 +523,13 @@ final class TimeSeries
         foreach ($chunks as $chunk) {
             $props[$chunk[0]] = $chunk[1];
         }
+
+        // maxSamplesPerChunk has been replaced with chunkSize in 1.4.4
+        // https://github.com/RedisTimeSeries/RedisTimeSeries/commit/5896a509e5ec30929c04cd96a7f8b2c9e9651ed9
+        $props['chunkSize'] = isset($props['chunkSize'])
+            ? $props['chunkSize']
+            : $props['maxSamplesPerChunk']
+            ;
 
         return $props;
     }

--- a/src/TimeSeries.php
+++ b/src/TimeSeries.php
@@ -491,20 +491,40 @@ final class TimeSeries
     public function info(string $key): Metadata
     {
         $result = $this->redis->executeCommand(['TS.INFO', $key]);
+        $result = $this->parseInfo($result);
 
         $labels = [];
-        foreach ($result[9] as $strLabel) {
-            $labels[] = new Label($strLabel[0], $strLabel[1]);
+        foreach ($result['labels'] as $label) {
+            $labels[] = new Label($label[0], $label[1]);
         }
 
-        $sourceKey = $result[11] === false ? null : $result[11];
+        $sourceKey = $result['sourceKey'] === false ? null : $result['sourceKey'];
 
         $rules = [];
-        foreach ($result[13] as $rule) {
+        foreach ($result['rules'] as $rule) {
             $rules[$rule[0]] = new AggregationRule($rule[2], $rule[1]);
         }
 
-        return Metadata::fromRedis($result[1], $result[3], $result[5], $result[7], $labels, $sourceKey, $rules);
+        return Metadata::fromRedis(
+            $result['lastTimestamp'],
+            $result['retentionTime'],
+            $result['chunkCount'],
+            $result['maxSamplesPerChunk'],
+            $labels,
+            $sourceKey,
+            $rules
+        );
+    }
+
+    protected function parseInfo(array $info)
+    {
+        $chunks = array_chunk($result, 2);
+        $props = [];
+        foreach ($chunks as $chunk) {
+            $props[$chunk[0]] = $chunk[1];
+        }
+
+        return $props;
     }
 
     /**


### PR DESCRIPTION
eliminate dependence on fixed positions of info properties. on version 1.8 of the ts module the info parsing broke because of hard-coded indexes.